### PR TITLE
fix-empty-terminal-cmdline

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -104,7 +104,7 @@ function executeSelection(e) {
   if (!e.selection) return;
   getselections(e);
   let txt;
-  if ((lsel[0] === lsel[1]) && (csel[0] !== csel[1]))
+  if ((lsel[0] !== lsel[1]) || (csel[0] !== csel[1]))
     sendterm(e.document.getText(e.selection));
 }
 

--- a/extension.js
+++ b/extension.js
@@ -6,37 +6,37 @@ let terminal;
 
 // ---------------------------------------------------------------------
 function activate(context) {
- const config = vscode.workspace.getConfiguration('j');
- const terminalName = 'Jconsole';
- const terminalCmd = config.executablePath;
+  const config = vscode.workspace.getConfiguration('j');
+  const terminalName = 'Jconsole';
+  const terminalCmd = config.executablePath;
 
- const createTerminal = () => {
-  terminal = vscode.window.createTerminal(terminalName, terminalCmd);
-  terminal.show();
- };
+  const createTerminal = () => {
+    terminal = vscode.window.createTerminal(terminalName, terminalCmd);
+    terminal.show();
+  };
 
- createTerminal();
+  createTerminal();
 
- let cmd;
- cmd = vscode.commands.registerTextEditorCommand('language-j.executeSelection', executeSelection);
- context.subscriptions.push(cmd);
- cmd = vscode.commands.registerTextEditorCommand('language-j.loadScript', loadScript);
- context.subscriptions.push(cmd);
- cmd = vscode.commands.registerTextEditorCommand('language-j.loadDisplayScript', loadDisplayScript);
- context.subscriptions.push(cmd);
- cmd = vscode.commands.registerTextEditorCommand('language-j.executeLine', executeLine);
- context.subscriptions.push(cmd);
- cmd = vscode.commands.registerTextEditorCommand('language-j.executeLineAdvance', executeLineAdvance);
- context.subscriptions.push(cmd); 
- cmd = vscode.commands.registerTextEditorCommand('language-j.createTerminal', createTerminal);
- context.subscriptions.push(cmd);
+  let cmd;
+  cmd = vscode.commands.registerTextEditorCommand('language-j.executeSelection', executeSelection);
+  context.subscriptions.push(cmd);
+  cmd = vscode.commands.registerTextEditorCommand('language-j.loadScript', loadScript);
+  context.subscriptions.push(cmd);
+  cmd = vscode.commands.registerTextEditorCommand('language-j.loadDisplayScript', loadDisplayScript);
+  context.subscriptions.push(cmd);
+  cmd = vscode.commands.registerTextEditorCommand('language-j.executeLine', executeLine);
+  context.subscriptions.push(cmd);
+  cmd = vscode.commands.registerTextEditorCommand('language-j.executeLineAdvance', executeLineAdvance);
+  context.subscriptions.push(cmd);
+  cmd = vscode.commands.registerTextEditorCommand('language-j.createTerminal', createTerminal);
+  context.subscriptions.push(cmd);
 
 }
 
 function deactivate() {
- if (terminal) {
-  terminal.dispose();
- }
+  if (terminal) {
+    terminal.dispose();
+  }
 }
 
 // ---------------------------------------------------------------------
@@ -47,33 +47,33 @@ exports.deactivate = deactivate;
 
 // ----------------------------------------------------------------------
 function has(array, element) {
- return -1 < array.indexOf(element);
+  return -1 < array.indexOf(element);
 }
 
 // ----------------------------------------------------------------------
 // return if line is start of multiline definition
 // checks only most common cases using standard library
 function ismultiline(t) {
- let s = t.trim();
- if (s.length === 0) return false;
- if ("Note'" === s.substring(0, 5)) return true;
- s = splitblankJ(s);
- if ("Note" === s[0]) return true;
- let len = s.length;
- let num = ["0", "1", "2", "3", "4"];
- let def = ["noun", "adverb", "conjunction", "verb", "monad", "dyad"];
- for (let i = 1; i < len; i++) {
-  if (s[i] !== "define" &&
-   (s[i] !== ":" || i === len - 1 || s[i + 1] !== "0")) continue;
-  if (has(def, s[i - 1]) || has(num, s[i - 1])) return true;
- }
- return false;
+  let s = t.trim();
+  if (s.length === 0) return false;
+  if ("Note'" === s.substring(0, 5)) return true;
+  s = splitblankJ(s);
+  if ("Note" === s[0]) return true;
+  let len = s.length;
+  let num = ["0", "1", "2", "3", "4"];
+  let def = ["noun", "adverb", "conjunction", "verb", "monad", "dyad"];
+  for (let i = 1; i < len; i++) {
+    if (s[i] !== "define" &&
+      (s[i] !== ":" || i === len - 1 || s[i + 1] !== "0")) continue;
+    if (has(def, s[i - 1]) || has(num, s[i - 1])) return true;
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------
 // split on blanks, ignoring J strings 'abc def'
 function splitblankJ(s) {
- return s.match(/(?:[^\s']+|'[^']*')+/g);
+  return s.match(/(?:[^\s']+|'[^']*')+/g);
 }
 
 // cmds
@@ -81,17 +81,17 @@ function splitblankJ(s) {
 // ---------------------------------------------------------------------
 // ctrl L loads current file in terminal
 function loadScript(e) {
- load(e, false);
+  load(e, false);
 }
 
 // ---------------------------------------------------------------------
 function loadDisplayScript(e) {
- load(e, true);
+  load(e, true);
 }
 
 // ---------------------------------------------------------------------
 function load(e, show) {
- sendterm("load" + (show ? "d" : "") + " '" + e.document.fileName + "'");
+  sendterm("load" + (show ? "d" : "") + " '" + e.document.fileName + "'");
 }
 
 // entry
@@ -101,85 +101,85 @@ let csel, lsel;
 // ---------------------------------------------------------------------
 // ctrl E runs selection on one line
 function executeSelection(e) {
- if (!e.selection) return;
- getselections(e);
- let txt;
- if ((lsel[0] === lsel[1]) && (csel[0] !== csel[1]))
-  sendterm(e.document.getText(e.selection));
+  if (!e.selection) return;
+  getselections(e);
+  let txt;
+  if ((lsel[0] === lsel[1]) && (csel[0] !== csel[1]))
+    sendterm(e.document.getText(e.selection));
 }
 
 // ---------------------------------------------------------------------
 function executeLine(e) {
- runline(e, false);
+  runline(e, false);
 }
 
 // ---------------------------------------------------------------------
 function executeLineAdvance(e) {
- runline(e, true);
+  runline(e, true);
 }
 
 // ---------------------------------------------------------------------
 function getline(e, p) {
- return e.document.lineAt(p).text;
+  return e.document.lineAt(p).text;
 }
 
 // ---------------------------------------------------------------------
 function getselections(e) {
- csel = [e.selection.start.character, e.selection.end.character];
- lsel = [e.selection.start.line, e.selection.end.line];
+  csel = [e.selection.start.character, e.selection.end.character];
+  lsel = [e.selection.start.line, e.selection.end.line];
 }
 
 // ---------------------------------------------------------------------
 function movecursor(n) {
- vscode.commands.executeCommand("cursorMove", {
-  to: "down",
-  by: "wrappedLine",
-  value: n
- });
- vscode.commands.executeCommand("cursorMove", {
-  to: "wrappedLineEnd"
- });
+  vscode.commands.executeCommand("cursorMove", {
+    to: "down",
+    by: "wrappedLine",
+    value: n
+  });
+  vscode.commands.executeCommand("cursorMove", {
+    to: "wrappedLineEnd"
+  });
 }
 
 // ---------------------------------------------------------------------
 // returns next non-empty line, entry from given position
 function readentry(e) {
- let res = readentry1(e);
- let p = res[0];
- while (p < e.document.lineCount) {
-  let s = getline(e, p);
-  if (s.trim().length) break;
-  p++;
- }
- return [p, res[1]];
+  let res = readentry1(e);
+  let p = res[0];
+  while (p < e.document.lineCount) {
+    let s = getline(e, p);
+    if (s.trim().length) break;
+    p++;
+  }
+  return [p, res[1]];
 }
 
 // ---------------------------------------------------------------------
 function readentry1(e) {
- let p = lsel[0];
- let r = getline(e, p++);
- if (r.trim().length === 0 || !ismultiline(r)) return [p, r];
- while (p < e.document.lineCount) {
-  let s = getline(e, p++);
-  r += "\n" + s;
-  if (s === ")") break;
- }
- return [p, r];
+  let p = lsel[0];
+  let r = getline(e, p++);
+  if (r.trim().length === 0 || !ismultiline(r)) return [p, r];
+  while (p < e.document.lineCount) {
+    let s = getline(e, p++);
+    r += "\n" + s;
+    if (s === ")") break;
+  }
+  return [p, r];
 };
 
 // ---------------------------------------------------------------------
 function runline(e, advance) {
- if (!e.selection) return;
- getselections(e);
- let res = readentry(e);
- let pos = res[0];
- let txt = res[1];
- sendterm(txt);
- if (advance)
-  movecursor(pos - lsel[0]);
+  if (!e.selection) return;
+  getselections(e);
+  let res = readentry(e);
+  let pos = res[0];
+  let txt = res[1];
+  sendterm(txt);
+  if (advance)
+    movecursor(pos - lsel[0]);
 }
 
 // ---------------------------------------------------------------------
 function sendterm(txt) {
- terminal.sendText('\u0015' + txt, !txt.endsWith('\n'));
+  terminal.sendText('\u0015' + txt, !txt.endsWith('\n'));
 }

--- a/extension.js
+++ b/extension.js
@@ -174,12 +174,12 @@ function runline(e, advance) {
  let res = readentry(e);
  let pos = res[0];
  let txt = res[1];
- terminal.sendText(txt, txt[txt.length - 1] !== '\n');
+ sendterm(txt);
  if (advance)
   movecursor(pos - lsel[0]);
 }
 
 // ---------------------------------------------------------------------
 function sendterm(txt) {
- terminal.sendText(txt, txt[txt.length - 1] !== '\n');
+ terminal.sendText('\u0015' + txt, !txt.endsWith('\n'));
 }

--- a/src/cmds.js
+++ b/src/cmds.js
@@ -3,15 +3,15 @@
 // ---------------------------------------------------------------------
 // ctrl L loads current file in terminal
 function loadScript(e) {
- load(e, false);
+  load(e, false);
 }
 
 // ---------------------------------------------------------------------
 function loadDisplayScript(e) {
- load(e, true);
+  load(e, true);
 }
 
 // ---------------------------------------------------------------------
 function load(e, show) {
- sendterm("load" + (show ? "d" : "") + " '" + e.document.fileName + "'");
+  sendterm("load" + (show ? "d" : "") + " '" + e.document.fileName + "'");
 }

--- a/src/entry.js
+++ b/src/entry.js
@@ -5,85 +5,85 @@ let csel, lsel;
 // ---------------------------------------------------------------------
 // ctrl E runs selection on one line
 function executeSelection(e) {
- if (!e.selection) return;
- getselections(e);
- let txt;
- if ((lsel[0] === lsel[1]) && (csel[0] !== csel[1]))
-  sendterm(e.document.getText(e.selection));
+  if (!e.selection) return;
+  getselections(e);
+  let txt;
+  if ((lsel[0] === lsel[1]) && (csel[0] !== csel[1]))
+    sendterm(e.document.getText(e.selection));
 }
 
 // ---------------------------------------------------------------------
 function executeLine(e) {
- runline(e, false);
+  runline(e, false);
 }
 
 // ---------------------------------------------------------------------
 function executeLineAdvance(e) {
- runline(e, true);
+  runline(e, true);
 }
 
 // ---------------------------------------------------------------------
 function getline(e, p) {
- return e.document.lineAt(p).text;
+  return e.document.lineAt(p).text;
 }
 
 // ---------------------------------------------------------------------
 function getselections(e) {
- csel = [e.selection.start.character, e.selection.end.character];
- lsel = [e.selection.start.line, e.selection.end.line];
+  csel = [e.selection.start.character, e.selection.end.character];
+  lsel = [e.selection.start.line, e.selection.end.line];
 }
 
 // ---------------------------------------------------------------------
 function movecursor(n) {
- vscode.commands.executeCommand("cursorMove", {
-  to: "down",
-  by: "wrappedLine",
-  value: n
- });
- vscode.commands.executeCommand("cursorMove", {
-  to: "wrappedLineEnd"
- });
+  vscode.commands.executeCommand("cursorMove", {
+    to: "down",
+    by: "wrappedLine",
+    value: n
+  });
+  vscode.commands.executeCommand("cursorMove", {
+    to: "wrappedLineEnd"
+  });
 }
 
 // ---------------------------------------------------------------------
 // returns next non-empty line, entry from given position
 function readentry(e) {
- let res = readentry1(e);
- let p = res[0];
- while (p < e.document.lineCount) {
-  let s = getline(e, p);
-  if (s.trim().length) break;
-  p++;
- }
- return [p, res[1]];
+  let res = readentry1(e);
+  let p = res[0];
+  while (p < e.document.lineCount) {
+    let s = getline(e, p);
+    if (s.trim().length) break;
+    p++;
+  }
+  return [p, res[1]];
 }
 
 // ---------------------------------------------------------------------
 function readentry1(e) {
- let p = lsel[0];
- let r = getline(e, p++);
- if (r.trim().length === 0 || !ismultiline(r)) return [p, r];
- while (p < e.document.lineCount) {
-  let s = getline(e, p++);
-  r += "\n" + s;
-  if (s === ")") break;
- }
- return [p, r];
+  let p = lsel[0];
+  let r = getline(e, p++);
+  if (r.trim().length === 0 || !ismultiline(r)) return [p, r];
+  while (p < e.document.lineCount) {
+    let s = getline(e, p++);
+    r += "\n" + s;
+    if (s === ")") break;
+  }
+  return [p, r];
 };
 
 // ---------------------------------------------------------------------
 function runline(e, advance) {
- if (!e.selection) return;
- getselections(e);
- let res = readentry(e);
- let pos = res[0];
- let txt = res[1];
- sendterm(txt);
- if (advance)
-  movecursor(pos - lsel[0]);
+  if (!e.selection) return;
+  getselections(e);
+  let res = readentry(e);
+  let pos = res[0];
+  let txt = res[1];
+  sendterm(txt);
+  if (advance)
+    movecursor(pos - lsel[0]);
 }
 
 // ---------------------------------------------------------------------
 function sendterm(txt) {
- terminal.sendText('\u0015' + txt, !txt.endsWith('\n'));
+  terminal.sendText('\u0015' + txt, !txt.endsWith('\n'));
 }

--- a/src/entry.js
+++ b/src/entry.js
@@ -8,7 +8,7 @@ function executeSelection(e) {
   if (!e.selection) return;
   getselections(e);
   let txt;
-  if ((lsel[0] === lsel[1]) && (csel[0] !== csel[1]))
+  if ((lsel[0] !== lsel[1]) || (csel[0] !== csel[1]))
     sendterm(e.document.getText(e.selection));
 }
 

--- a/src/entry.js
+++ b/src/entry.js
@@ -78,12 +78,12 @@ function runline(e, advance) {
  let res = readentry(e);
  let pos = res[0];
  let txt = res[1];
- terminal.sendText(txt, txt[txt.length - 1] !== '\n');
+ sendterm(txt);
  if (advance)
   movecursor(pos - lsel[0]);
 }
 
 // ---------------------------------------------------------------------
 function sendterm(txt) {
- terminal.sendText(txt, txt[txt.length - 1] !== '\n');
+ terminal.sendText('\u0015' + txt, !txt.endsWith('\n'));
 }

--- a/src/main.js
+++ b/src/main.js
@@ -6,37 +6,37 @@ let terminal;
 
 // ---------------------------------------------------------------------
 function activate(context) {
- const config = vscode.workspace.getConfiguration('j');
- const terminalName = 'Jconsole';
- const terminalCmd = config.executablePath;
+  const config = vscode.workspace.getConfiguration('j');
+  const terminalName = 'Jconsole';
+  const terminalCmd = config.executablePath;
 
- const createTerminal = () => {
-  terminal = vscode.window.createTerminal(terminalName, terminalCmd);
-  terminal.show();
- };
+  const createTerminal = () => {
+    terminal = vscode.window.createTerminal(terminalName, terminalCmd);
+    terminal.show();
+  };
 
- createTerminal();
+  createTerminal();
 
- let cmd;
- cmd = vscode.commands.registerTextEditorCommand('language-j.executeSelection', executeSelection);
- context.subscriptions.push(cmd);
- cmd = vscode.commands.registerTextEditorCommand('language-j.loadScript', loadScript);
- context.subscriptions.push(cmd);
- cmd = vscode.commands.registerTextEditorCommand('language-j.loadDisplayScript', loadDisplayScript);
- context.subscriptions.push(cmd);
- cmd = vscode.commands.registerTextEditorCommand('language-j.executeLine', executeLine);
- context.subscriptions.push(cmd);
- cmd = vscode.commands.registerTextEditorCommand('language-j.executeLineAdvance', executeLineAdvance);
- context.subscriptions.push(cmd); 
- cmd = vscode.commands.registerTextEditorCommand('language-j.createTerminal', createTerminal);
- context.subscriptions.push(cmd);
+  let cmd;
+  cmd = vscode.commands.registerTextEditorCommand('language-j.executeSelection', executeSelection);
+  context.subscriptions.push(cmd);
+  cmd = vscode.commands.registerTextEditorCommand('language-j.loadScript', loadScript);
+  context.subscriptions.push(cmd);
+  cmd = vscode.commands.registerTextEditorCommand('language-j.loadDisplayScript', loadDisplayScript);
+  context.subscriptions.push(cmd);
+  cmd = vscode.commands.registerTextEditorCommand('language-j.executeLine', executeLine);
+  context.subscriptions.push(cmd);
+  cmd = vscode.commands.registerTextEditorCommand('language-j.executeLineAdvance', executeLineAdvance);
+  context.subscriptions.push(cmd);
+  cmd = vscode.commands.registerTextEditorCommand('language-j.createTerminal', createTerminal);
+  context.subscriptions.push(cmd);
 
 }
 
 function deactivate() {
- if (terminal) {
-  terminal.dispose();
- }
+  if (terminal) {
+    terminal.dispose();
+  }
 }
 
 // ---------------------------------------------------------------------

--- a/src/util.js
+++ b/src/util.js
@@ -2,31 +2,31 @@
 
 // ----------------------------------------------------------------------
 function has(array, element) {
- return -1 < array.indexOf(element);
+  return -1 < array.indexOf(element);
 }
 
 // ----------------------------------------------------------------------
 // return if line is start of multiline definition
 // checks only most common cases using standard library
 function ismultiline(t) {
- let s = t.trim();
- if (s.length === 0) return false;
- if ("Note'" === s.substring(0, 5)) return true;
- s = splitblankJ(s);
- if ("Note" === s[0]) return true;
- let len = s.length;
- let num = ["0", "1", "2", "3", "4"];
- let def = ["noun", "adverb", "conjunction", "verb", "monad", "dyad"];
- for (let i = 1; i < len; i++) {
-  if (s[i] !== "define" &&
-   (s[i] !== ":" || i === len - 1 || s[i + 1] !== "0")) continue;
-  if (has(def, s[i - 1]) || has(num, s[i - 1])) return true;
- }
- return false;
+  let s = t.trim();
+  if (s.length === 0) return false;
+  if ("Note'" === s.substring(0, 5)) return true;
+  s = splitblankJ(s);
+  if ("Note" === s[0]) return true;
+  let len = s.length;
+  let num = ["0", "1", "2", "3", "4"];
+  let def = ["noun", "adverb", "conjunction", "verb", "monad", "dyad"];
+  for (let i = 1; i < len; i++) {
+    if (s[i] !== "define" &&
+      (s[i] !== ":" || i === len - 1 || s[i + 1] !== "0")) continue;
+    if (has(def, s[i - 1]) || has(num, s[i - 1])) return true;
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------
 // split on blanks, ignoring J strings 'abc def'
 function splitblankJ(s) {
- return s.match(/(?:[^\s']+|'[^']*')+/g);
+  return s.match(/(?:[^\s']+|'[^']*')+/g);
 }


### PR DESCRIPTION
Prefixes each command sent to terminal with control characters to delete the current command line. Fixes #8
This is also a workaround for #6 by allowing the user to manually select a multiline block of code and execute it, but doesn't fully addresss the issue.