### PR TITLE
Add command to open NuVoc in web browser

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -8,7 +8,8 @@ function activate(context) {
         ['language-j.loadScript', loadScript],
         ['language-j.loadDisplayScript', loadDisplayScript],
         ['language-j.execute', execute],
-        ['language-j.executeAdvance', executeAdvance]
+        ['language-j.executeAdvance', executeAdvance],
+        ['language-j.openNuVoc', openNuVoc]
     ];
     for (const [n, f] of cmds) {
         vscode_1.commands.registerTextEditorCommand(n, f);
@@ -128,4 +129,7 @@ function sendTerminalText(txt) {
     }
     getTerminal();
     terminal.sendText(clearline + txt, !txt.endsWith('\n'));
+}
+function openNuVoc(editor) {
+    vscode_1.env.openExternal(vscode_1.Uri.parse('https://code.jsoftware.com/wiki/NuVoc'));
 }

--- a/package.json
+++ b/package.json
@@ -77,6 +77,10 @@
             {
                 "command": "language-j.startTerminal",
                 "title": "J: Start new JConsole Terminal"
+            },
+            {
+                "command": "language-j.openNuVoc",
+                "title": "J: Open NuVoc Help in Browser"
             }
         ],
         "keybindings": [


### PR DESCRIPTION
Thanks for contributing this plugin!

I use the default `F1` binding in JQT to open NuVoc quite frequently. This provides the command, but I didn't add a default key binding.

I also chose the wording `"Open NuVoc Help in Browser"` to ensure that typing `j` and `help` would match this entry for users looking for J help via the VS Code command palette.